### PR TITLE
Fixed build creation based on the comment - Use a .npmignore file to …

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 node_modules
 coverage
-dist
+src
 .DS_Store
 .vscode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescriptds",
-  "version": "0.1.3-alpha",
+  "version": "0.1.4-alpha",
   "description": "Data Structures in TypeScript",
   "author": "Madhur Ahuja",
   "main": "dist/index.js",


### PR DESCRIPTION
…keep stuff out of your package. If there's no .npmignore file, but there is a .gitignore file, then npm will ignore the stuff matched by the .gitignore file. If you want to include something that is excluded by your .gitignore file, you can create an empty .npmignore file to override it. Like git, npm looks for .npmignore and .gitignore files in all subdirectories of your package, not only the root directory.