### PR TITLE
Fix id type inconsistencies and stack/queue bugs

### DIFF
--- a/src/graph/graph.ts
+++ b/src/graph/graph.ts
@@ -2,7 +2,7 @@ import { Errors } from '../errors.enum';
 import Vertex from './vertex';
 
 export default class Graph<T> {
-  vertices = new Map();
+  vertices: Map<string, Vertex<T>> = new Map();
 
   /**
    * To add node in the graph

--- a/src/graph/vertex.ts
+++ b/src/graph/vertex.ts
@@ -3,9 +3,9 @@ import { v4 as uuidv4 } from 'uuid';
 
 export default class Vertex<T> {
   private types: VertexType[];
-  id: number;
+  id: string;
   value: T;
-  edges?: Map<number, Vertex<T>> = new Map();
+  edges: Map<string, Vertex<T>> = new Map();
 
   constructor(value: T) {
     this.id = uuidv4();

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -15,11 +15,11 @@ export default class Queue<T> {
      * To get the head element of the queue and remove the head
      * @returns T
      */
-    dequeue() {
+    dequeue(): T {
         if (this.isEmpty) {
             throw new Error(Errors.QUEUE_EMPTY);
         }
-        return this.store.shift();
+        return this.store.shift() as T;
     }
 
     /**

--- a/src/stack/stack.ts
+++ b/src/stack/stack.ts
@@ -19,7 +19,7 @@ export default class Stack<T> {
             throw new Error(Errors.STACK_EMPTY);
         }
         const topItem = this.peek();
-        this.store.splice(this.size - 1);
+        this.store.splice(this.size - 1, 1);
         return topItem;
     }
 

--- a/src/tree/node.ts
+++ b/src/tree/node.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 export default class Node<T> {
-    id: number;
+    id: string;
     value: T;
     branchNodes: Node<T>[];
     //right: Node<T>[];

--- a/src/tree/tree.ts
+++ b/src/tree/tree.ts
@@ -1,7 +1,7 @@
 import Node from './node';
 
 export default class Tree<T> {
-    nodes = new Map();
+    nodes: Map<string, Node<T>> = new Map();
 
     /**
      * To add a node in the tree
@@ -23,7 +23,7 @@ export default class Tree<T> {
      * To get a node from the tree
      * @param nodeId
      */
-    getNode(nodeId: number) {
+    getNode(nodeId: string) {
         return this.nodes.get(nodeId);
     }
 }


### PR DESCRIPTION
## Summary
- ensure graph vertices and tree nodes use string ids
- tighten generic types on collections
- correct queue dequeue return type
- fix stack pop to remove only the top item

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b4c7cba483208b7b6212c09128f3